### PR TITLE
enable non serializable objects. 

### DIFF
--- a/upickle/js/src/main/scala/upickle/json/package.scala
+++ b/upickle/js/src/main/scala/upickle/json/package.scala
@@ -1,6 +1,8 @@
 package upickle
-import acyclic.file
-import scalajs.js
+
+import upickle.Js.Other
+
+import scala.scalajs.js
 
 
 package object json {
@@ -12,6 +14,11 @@ package object json {
     case false => Js.False
     case null => Js.Null
     case s: js.Array[_] => Js.Arr(s.map(readJs(_: Any)):_*)
+    //this does not actually work:
+    //to know that one should map to Other(... ) would
+    //require one to know that the object mapped to extends js.Any, not that the input is js.Any
+    //which it inevitably is here.
+    case cloneable: js.Any => Other(cloneable)
     case s: js.Object => Js.Obj(s.asInstanceOf[js.Dictionary[_]].mapValues(readJs).toSeq:_*)
   }
 
@@ -32,6 +39,7 @@ package object json {
     case Js.Null => null
     case Js.Arr(children@_*) => js.Array(children.map(writeJs(_)):_*)
     case Js.Obj(kvs@_*) => js.Dictionary(kvs.map{case (k, v) => (k, writeJs(v))}:_*)
+    case Js.Other(t) => t.asInstanceOf[js.Any]
   }
 
   def write(v: Js.Value): String =

--- a/upickle/shared/src/main/scala/upickle/Js.scala
+++ b/upickle/shared/src/main/scala/upickle/Js.scala
@@ -59,5 +59,7 @@ object Js {
   case object Null extends Value{
     def value = null
   }
+  //for objects that cannot be serialised but can be used in an AST
+  case class Unserializable[T](value: T) extends AnyVal with Value
 }
 

--- a/upickle/shared/src/main/scala/upickle/Js.scala
+++ b/upickle/shared/src/main/scala/upickle/Js.scala
@@ -59,7 +59,7 @@ object Js {
   case object Null extends Value{
     def value = null
   }
-  //for objects that cannot be serialised but can be used in an AST
-  case class Unserializable[T](value: T) extends AnyVal with Value
+  //for other objects that are already json (or cloneable ) objects ( eg. js.Any )
+  case class Other[T](value: T) extends AnyVal with Value
 }
 


### PR DESCRIPTION
This is needed for turning JS CryptoAPI opaque objects into an AST to send to IndexedDB as explained in https://groups.google.com/d/msg/scala-js/9QLzClZSGtQ/1pJ8fPbxCAAJ
For a usage see the "non hacky Key saving to DB" commit on read-write-web below, which allows me to remove the hack I needed for https://github.com/viagraphs/scalajs-rx-idb/issues/3