### PR TITLE
fixes an issue impacting derivation of sealed traits

### DIFF
--- a/derive/shared/src/main/scala/derive/Derive.scala
+++ b/derive/shared/src/main/scala/derive/Derive.scala
@@ -27,6 +27,7 @@ trait DeriveApi[M[_]]{
 abstract class Derive[M[_]] extends DeriveApi[M]{
   case class TypeKey(t: c.Type) {
     override def equals(o: Any) = t =:= o.asInstanceOf[TypeKey].t
+    override def hashCode: Int = t.typeSymbol.fullName.hashCode
   }
   import c.universe._
   import compat._

--- a/upickle/shared/src/test/scala/upickle/AdvancedTests.scala
+++ b/upickle/shared/src/test/scala/upickle/AdvancedTests.scala
@@ -1,0 +1,41 @@
+package upickle
+import utest._
+import acyclic.file
+
+object shared {
+  object that {
+    import common.Message
+    case class That(common: Message)
+  }
+  object other {
+    import common.Message
+    case class Other(common: Message)
+  }
+  object common {
+    case class Message(content: String)
+  }
+}
+
+object All {
+  import shared.other._
+  sealed trait Outers
+  case class Out1(a: Other) extends Outers
+
+  import shared.that._
+  import shared.common._
+  sealed trait Inners extends Outers
+  case class Inner1(b: That) extends Inners
+  case class Inner2(a: Message) extends Inners
+}
+
+object AdvancedTests extends TestSuite{
+  import All._
+  val tests = TestSuite{
+    "complexTraits" - {
+      val reader = implicitly[upickle.default.Reader[Outers]]
+      val writer = implicitly[upickle.default.Writer[Outers]]
+      assert(reader != null)
+      assert(writer != null)
+    }
+  }
+}


### PR DESCRIPTION
I think #124 was the root cause of this particular problem. The problem was that during the macro derivation the `seen` set of TypeKeys was returning false in instances where it should have returned true and thus was generating "ambiguous" implicits for the same type by generating multiple instances for that type. 

In the test code's case, the problematic instance was `shared.common.Message`. Giving an explicit, and hopefully sensible, hashCode fixes the problem as `seen` returns the expected result. 