### PR TITLE
Changed implicit order for deriving Reader/Writer for seqish V[T]

### DIFF
--- a/upickle/shared/src/main/scala/upickle/Implicits.scala
+++ b/upickle/shared/src/main/scala/upickle/Implicits.scala
@@ -134,12 +134,12 @@ trait Implicits extends Types { imp: Generated =>
   implicit val DoubleRW = NumericReadWriter(_.toDouble, _.toDouble)
 
   import collection.generic.CanBuildFrom
-  implicit def SeqishR[V[_], T: R]
-                       (implicit cbf: CanBuildFrom[Nothing, T, V[T]]): R[V[T]] = R[V[T]](
+  implicit def SeqishR[V[_], T]
+                       (implicit cbf: CanBuildFrom[Nothing, T, V[T]], r: R[T]): R[V[T]] = R[V[T]](
     Internal.validate("Array(n)"){case Js.Arr(x@_*) => x.map(readJs[T]).to[V]}
   )
 
-  implicit def SeqishW[T: W, V[_] <: Iterable[_]]: W[V[T]] = W[V[T]]{
+  implicit def SeqishW[T, V[_]](implicit v: V[_] <:< Iterable[_], w: W[T]): W[V[T]] = W[V[T]]{
     (x: V[T]) => Js.Arr(x.iterator.asInstanceOf[Iterator[T]].map(writeJs(_)).toArray:_*)
   }
 


### PR DESCRIPTION
This allows for dramatically reduced compilation times in certain scenarios. Taken from https://github.com/patrick-premont/upickle-pprint/commit/529b9fa6956b36d32fe56168209b5567a3127f1a. Addresses #137