### PR TITLE
Added getMessage() for Invalid.Json and Invalid.Data exceptions

### DIFF
--- a/upickle/shared/src/main/scala/upickle/Js.scala
+++ b/upickle/shared/src/main/scala/upickle/Js.scala
@@ -19,7 +19,9 @@ object Invalid{
    */
   case class Json(msg: String, input: String)
     extends scala.Exception()
-    with Invalid
+    with Invalid {
+    override def getMessage(): String = s"$msg (input: $input)"
+  }
 
   /**
    * Thrown when uPickle tries to convert a JSON blob into a given data
@@ -31,7 +33,9 @@ object Invalid{
    */
   case class Data(data: Js.Value, msg: String)
     extends Exception()
-    with Invalid
+    with Invalid {
+    override def getMessage(): String = s"$msg (data: $data)"
+  }
 }
 
 /**


### PR DESCRIPTION
This enables a nicer description of the exemption when it gets printed as part of a stack trace.