### PR TITLE
Write long number that have no decimals without decimals

### DIFF
--- a/upickle/jvm/src/main/scala/upickle/json/Jawn.scala
+++ b/upickle/jvm/src/main/scala/upickle/json/Jawn.scala
@@ -59,7 +59,7 @@ sealed trait Renderer {
       case Js.Null => sb.append("null")
       case Js.True => sb.append("true")
       case Js.False => sb.append("false")
-      case Js.Num(n) => sb.append(if (n == n.toInt) n.toInt.toString else n.toString)
+      case Js.Num(n) => sb.append(if (n == n.toLong) n.toLong.toString else n.toString)
       case Js.Str(s) => renderString(sb, s)
       case Js.Arr(vs@_*) => renderArray(sb, depth, vs, indent)
       case Js.Obj(vs@_*) => renderObject(sb, depth, canonicalizeObject(vs), indent)

--- a/upickle/shared/src/test/scala/upickle/PrimitiveTests.scala
+++ b/upickle/shared/src/test/scala/upickle/PrimitiveTests.scala
@@ -45,6 +45,7 @@ object PrimitiveTests extends TestSuite{
 
     'Double{
       'whole-rw(125123: Double, """125123.0""", """125123""")
+      'wholeLarge-rw(1475741505173L: Double, """1475741505173.0""", """1475741505173""")
       'fractional-rw(125123.1542312, """125123.1542312""")
       'negative-rw(-125123.1542312, """-125123.1542312""")
       'null-assert(read[Double]("null") == 0.0)


### PR DESCRIPTION
The benefit is that millisecond timestamps are not encoded with scientific notation.

For example:
  1475741505173L
  becomes 1475741505173
  instead of 1.475741505173E12

I'm getting a lot of warnings in sbt (deprecation, scala version). Is that normal?