### PR TITLE
Add java8 time support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,13 @@ val upickle = crossProject
             ${tuples.mkString("\n")}
           }
         """)
-      Seq(file)
+      val fileExtensions=GeneratedExtension.nameAndSource.map{case (nme,src)=>
+        val f = dir / "upickle" / (nme+".scala")
+        IO.write(f,src)
+        f
+      }
+
+      Seq(file) ++ fileExtensions
     }.taskValue
   ).jsSettings(
     scalaJSStage in Test := FullOptStage,

--- a/project/GeneratedExtension.scala
+++ b/project/GeneratedExtension.scala
@@ -1,0 +1,34 @@
+import sbt._
+import sbt.Keys._
+
+/**
+  * Hold generated sources for extra types.
+  */
+object GeneratedExtension {
+  private val java8TimeSource = {
+    val java8Time =
+      Seq("LocalDate", "LocalTime", "LocalDateTime", "OffsetTime", "OffsetDateTime", "ZonedDateTime", "Instant")
+        .map { tpe =>
+          s"""
+         implicit val ${tpe}W = W[$tpe](dt => Js.Str(dt.toString))
+         implicit val ${tpe}R = R[$tpe]{case Js.Str(s) => $tpe.parse(s)}
+         """
+        }
+
+    val src=s"""
+      package upickle
+      import java.time._
+
+      /**
+       * Auto-generated picklers and unpicklers, used for java8 time types.
+       */
+      trait GeneratedJava8Time extends Types{
+        import Aliases._
+        ${java8Time.mkString("\n")}
+      }
+    """
+    ("GeneratedJava8Time",src)
+  }
+
+  val nameAndSource:Seq[(String,String)]=Seq(java8TimeSource)
+}

--- a/test/src/test/scala/java8time/Java8TimeTest.scala
+++ b/test/src/test/scala/java8time/Java8TimeTest.scala
@@ -1,0 +1,61 @@
+package java8time
+
+import java.time._
+
+import upickle.default._
+import utest._
+import utest.framework.{Test, Tree}
+
+
+object Java8TimeTest extends TestSuite {
+  val tests: Tree[Test] = this {
+    'LocalDate {
+      val date = LocalDate.of(2017, 2, 1)
+      val dateSer = write(date)
+      println(dateSer)
+      val dateDeser = read[LocalDate](dateSer)
+      assert(dateDeser.equals(date))
+    }
+    'LocalTime {
+      val time = LocalTime.of(22, 1)
+      val timeSer = write(time)
+      println(timeSer)
+      val timeDeser = read[LocalTime](timeSer)
+      assert(time == timeDeser)
+    }
+    'InstantAndCaseClass {
+      val snapshot = Instant.now()
+      val data = MyData(snapshot,89843L)
+      val dataSer=write(data)
+      println(dataSer)
+      val dataDeser=read[MyData](dataSer)
+      assert(dataDeser.snapshot == snapshot)
+    }
+    'Instant2ZonedDateTime{
+      val snapshot = Instant.now()
+      val data=MyData(snapshot,89843L)
+      val dataSer=write(data)
+      val dataDeser2=read[MyData2](dataSer)
+      println(dataDeser2)
+      assert(dataDeser2.isInstanceOf[MyData2] && dataDeser2.snapshot.toInstant == data.snapshot)
+    }
+    'OtherTypes{
+      val t1=LocalDateTime.now()
+      val ser1=write(t1)
+      val deser1=read[LocalDateTime](ser1)
+      assert(t1==deser1)
+
+      val t2=OffsetTime.now()
+      val ser2=write(t2)
+      val deser2=read[OffsetTime](ser2)
+      assert(t2==deser2)
+
+      val t3=OffsetDateTime.now()
+      val ser3=write(t3)
+      val deser3=read[OffsetDateTime](ser3)
+      assert(t3==deser3)
+    }
+  }
+}
+case class MyData(snapshot: Instant, data: Long)
+case class MyData2(snapshot: ZonedDateTime,data:Long)

--- a/upickle/shared/src/main/scala/upickle/Api.scala
+++ b/upickle/shared/src/main/scala/upickle/Api.scala
@@ -10,7 +10,7 @@ import language.higherKinds
  * its behavior. Override the `annotate` methods to control how a sealed
  * trait instance is tagged during reading and writing.
  */
-trait Api extends Types with Implicits with Generated with LowPriX{
+trait Api extends Types with Implicits with Generated with GeneratedJava8Time with LowPriX{
   protected[this] def validate[T](name: String)(pf: PartialFunction[Js.Value, T]) = Internal.validate(name)(pf)
 
   type key = derive.key

--- a/upickleReadme/Readme.scalatex
+++ b/upickleReadme/Readme.scalatex
@@ -99,6 +99,8 @@
         @code{UUID}s
       @li
         @hl.scala{null}
+      @li
+        java8 time:@code{LocalDate},@code{LocalTime},@code{LocalDateTime},@code{OffsetTime},@code{OffsetDateTime},@code{ZonedDateTime},@code{Instant}
     @p
       Readability/writability is recursive: a container such as a @code{Tuple} or @hl.scala{case class} is only readable if all its contents are readable, and only writable if all its contents are writable. That means that you cannot serialize a @hl.scala{List[Any]}, since uPickle doesn't provide a generic way of serializing @code{Any}. Case classes are only serializable up to 22 fields.
 


### PR DESCRIPTION
This lifts the JVM version threshold. Plus, custom pickler does not require much effort in client code. However, java8 time is used more and more, convenience gained wins the tradeoff.

Add a `project/GeneratedExtension.scala` to generate source, and save source to file in  `build.sbt`.
Mix trait `GeneratedJava8Time` that contains `implicit` into `Api` 