### PR TITLE
Fix #190

### DIFF
--- a/derive/shared/src/test/scala/derive/ClassDefs.scala
+++ b/derive/shared/src/test/scala/derive/ClassDefs.scala
@@ -94,6 +94,7 @@ object MixedIn extends MixedIn
 
 object Varargs{
   case class Sentence(a: String, bs: String*)
+  case class SingleArg(args: String*)
 }
 object Covariant{
   case class Tree[+T](value: T)

--- a/pprint/shared/src/test/scala/test/pprint/DerivationTests.scala
+++ b/pprint/shared/src/test/scala/test/pprint/DerivationTests.scala
@@ -64,6 +64,7 @@ object DerivationTests extends TestSuite{
     'varargs {
       import derive.Varargs._
       Check(Sentence("omg", "2", "3"), """Sentence("omg", Array("2", "3"))""")
+      Check(SingleArg("omg", "2", "3"), """SingleArg(Array("omg", "2", "3"))""")
     }
     'genericADTs {
       import derive.GenericADTs._

--- a/upickle/shared/src/main/scala/upickle/Macros.scala
+++ b/upickle/shared/src/main/scala/upickle/Macros.scala
@@ -46,9 +46,18 @@ object Macros {
                   argType: c.Type,
                   targetType: c.Type) = {
       val defaults = deriveDefaults(companion,1)
+      val isVararg = targetType.members.exists {
+        case m: MethodSymbol => m.isPrimaryConstructor && m.isVarargs
+        case _ => false
+      }
+      val applyArg = if (isVararg) {
+        q"x: _*"
+      } else {
+        q"x"
+      }
       q"""
         ${c.prefix}.CaseR[_root_.scala.Tuple1[$argType], $targetType](
-          _ match {case _root_.scala.Tuple1(x) => $companion.apply[..$typeArgs](x)},
+          _ match {case _root_.scala.Tuple1(x) => $companion.apply[..$typeArgs]($applyArg)},
           _root_.scala.Array($arg),
           _root_.scala.Array(..$defaults)
         )(${c.prefix}.Tuple1R)

--- a/upickle/shared/src/test/scala/upickle/MacroTests.scala
+++ b/upickle/shared/src/test/scala/upickle/MacroTests.scala
@@ -361,6 +361,8 @@ object MacroTests extends TestSuite{
     'varargs{
       rw(Varargs.Sentence("a", "b", "c"), """{"a":"a","bs":["b","c"]}""")
       rw(Varargs.Sentence("a"), """{"a":"a","bs":[]}""")
+      rw(Varargs.SingleArg("a", "b", "c"), """{"args":["a","b","c"]}""")
+      rw(Varargs.SingleArg("a"), """{"args":["a"]}""")
     }
       'performance{
         import Generic.ADT


### PR DESCRIPTION
Single-argument vararg constructors require a special treatment in a macro for `case1`-Reader (`: _*`).